### PR TITLE
fix linux link error

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -71,7 +71,8 @@ class HeapHistoryViewer(ConanFile):
        "qt:qtspeech": False,
        "qt:qtnetworkauth": False,
        "qt:qtremoteobjects": False,
-       "qt:qtwebglplugin": False
+       "qt:qtwebglplugin": False,
+       "fontconfig:shared": True,
     }
 
     def requirements(self):


### PR DESCRIPTION
.../fontconfig/2.13.91/conan/stable/package/ff803218363c298c0384e576f6dcdfe41b4281f9/lib/libfontconfig.a(fcfreetype.o): In function `FcFreeTypeQueryFaceInternal':
.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:1875: undefined reference to `FT_Get_BDF_Property'
.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:1882: undefined reference to `FT_Get_BDF_Property'
.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:1905: undefined reference to `FT_Get_BDF_Property'
.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:2008: undefined reference to `FT_Get_BDF_Property'
.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:2029: undefined reference to `FT_Get_BDF_Property'
/home/eric/.conan/data/fontconfig/2.13.91/conan/stable/package/ff803218363c298c0384e576f6dcdfe41b4281f9/lib/libfontconfig.a(fcfreetype.o):.../fontconfig/2.13.91/conan/stable/build/ff803218363c298c0384e576f6dcdfe41b4281f9/src/../source_subfolder/src/fcfreetype.c:1095: more undefined references to `FT_Get_BDF_Property' follow